### PR TITLE
Modernize for 2025 (Python 3.9+ only)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,11 +5,6 @@ verify_ssl = true
 name = "pypi"
 
 
-[packages]
-
-typing = "*"
-
-
 [dev-packages]
 
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ name = "pypi"
 [packages]
 
 attrs = "*"
-six = "*"
 typing = "*"
 
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 
 [packages]
 
-attrs = "*"
 typing = "*"
 
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,13 +34,6 @@
             ],
             "version": "==18.1.0"
         },
-        "six": {
-            "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
-            ],
-            "version": "==1.11.0"
-        },
         "typing": {
             "hashes": [
                 "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
@@ -245,13 +238,6 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
-        },
-        "six": {
-            "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
-            ],
-            "version": "==1.11.0"
         },
         "snowballstemmer": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,13 +27,6 @@
         ]
     },
     "default": {
-        "attrs": {
-            "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
-            ],
-            "version": "==18.1.0"
-        },
         "typing": {
             "hashes": [
                 "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
@@ -50,13 +43,6 @@
                 "sha256:37cdcb9e9954ed60912ebc1ca12a9d12178c26637abdf124e3cde2341c257fe0"
             ],
             "version": "==0.7.10"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
-            ],
-            "version": "==18.1.0"
         },
         "babel": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,16 +26,7 @@
             }
         ]
     },
-    "default": {
-        "typing": {
-            "hashes": [
-                "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
-                "sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf",
-                "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
-            ],
-            "version": "==3.6.4"
-        }
-    },
+    "default": {},
     "develop": {
         "alabaster": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=[
-        'typing',
-    ],
     package_dir={"": "src"},
     packages=find_packages("src"),
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ EXTRAS = {
 setup(
     name='mqttpacket',
     version='0.0.0',
+    python_requires='>=3.9',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -23,15 +24,15 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
         'attrs',
-        'six',
         'typing',
     ],
     package_dir={"": "src"},

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        'attrs',
         'typing',
     ],
     package_dir={"": "src"},

--- a/src/mqttpacket/v311/__init__.py
+++ b/src/mqttpacket/v311/__init__.py
@@ -22,6 +22,7 @@ from ._parsing import (
 )
 
 from ._packet import (
+    MQTTPacket,
     ConnackPacket,
     SubackPacket,
     PublishPacket,

--- a/src/mqttpacket/v311/__init__.py
+++ b/src/mqttpacket/v311/__init__.py
@@ -16,6 +16,7 @@ from ._builders import (
 
 from ._parsing import (
     parse,
+    parse_into,
     parse_connack,
 )
 

--- a/src/mqttpacket/v311/__init__.py
+++ b/src/mqttpacket/v311/__init__.py
@@ -10,6 +10,7 @@ from ._builders import (
     subscribe,
     encode_remainining_length,
     disconnect,
+    puback,
     publish,
     unsubscribe,
 )

--- a/src/mqttpacket/v311/__init__.py
+++ b/src/mqttpacket/v311/__init__.py
@@ -18,6 +18,7 @@ from ._builders import (
 from ._parsing import (
     parse,
     parse_into,
+    parse_one,
     parse_connack,
 )
 

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -5,9 +5,12 @@ See LICENSE for details.
 import struct
 from typing import Optional
 
-import attr
-
+from dataclasses import field
 from . import _constants
+
+# wrapped for Python < 3.10
+from ._packet import dataclass
+
 
 _CONNECT_REMAINING_LENGTH = 10
 
@@ -58,43 +61,28 @@ def encode_string(text):
     return b''.join([text_len, encoded_text])
 
 
-@attr.s
-class ConnectSpec(object):
+@dataclass
+class ConnectSpec:
     """
     Data class for connection related options.
     """
-    username = attr.ib(
-        default=None,
-        validator=_check_none_or_text,
-    )
-    password = attr.ib(
-        default=None,
-        validator=[
-            _check_none_or_text,
-            _check_password,
-        ],
-    )
-    will_topic = attr.ib(
-        default=None,
-        validator=[
-            _check_none_or_text,
-            _check_will_topic
-        ],
-    )
-    will_message = attr.ib(
-        default=None,
-        validator=[
-            _check_none_or_text,
-            _check_will_message
-        ]
-    )
-    will_qos = attr.ib(
-        default=0x00,
-        validator=[
-            attr.validators.in_(_constants.VALID_QOS),
-            _check_will_qos,
-        ]
-    )
+    username: Optional[str] = None
+    password: Optional[str] = None
+    will_topic: Optional[str] = None
+    will_message: Optional[str] = None
+    will_qos: int = 0x00
+
+    def __post_init__(self):
+        if self.password is not None and self.username is None:
+            raise ValueError('Password requires username.')
+        if self.will_topic is not None and self.will_message is None:
+            raise ValueError('Will message must be set with will topic')
+        if self.will_message is not None and self.will_topic is None:
+            raise ValueError('Will topic must be set with will message')
+        if self.will_qos != 0x00 and self.will_topic is None:
+            raise ValueError('Will QOS requires topic/message')
+        if self.will_qos not in _constants.VALID_QOS:
+            raise ValueError('qos must be 0 <= qos < 3')
 
     def flags(self):
         """Get the flags for this connect spec."""
@@ -195,27 +183,20 @@ def pingreq():
     return b'\xc0\x00'
 
 
-def _validate_qos(_instance, _attribute, value):
-    if not 0 <= value < 3:
-        raise ValueError('qos must be 0 <= qos < 3')
-
-
-@attr.s(slots=True)
-class SubscriptionSpec(object):
+@dataclass(slots=True)
+class SubscriptionSpec:
     """
     A data class for a topicfilter qos pair.
     """
-    topicfilter = attr.ib(
-        validator=attr.validators.instance_of(str),
-    )
+    topicfilter: str
 
-    qos = attr.ib(
-        validator=_validate_qos,
-    )
+    qos: int
 
-    _encoded = attr.ib(init=False)
+    _encoded: bytes = field(init=False)
 
-    def __attrs_post_init__(self):
+    def __post_init__(self):
+        if not 0 <= self.qos < 3:
+            raise ValueError('qos must be 0 <= qos < 3')
         self._encoded = self.topicfilter.encode('utf-8')
 
     def remaining_len(self):

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -250,6 +250,20 @@ def disconnect() -> bytes:
     )
 
 
+def puback(packet_id: int):
+    """Build a PUBACK packet.
+    """
+    if not 0 < packet_id < 65535:
+        raise ValueError('Packetid must be 0 < packetid < 65535')
+
+    return struct.pack(
+        "!BBH",
+        (_constants.MQTT_PACKET_PUBACK << 4),
+        2,
+        packet_id
+    )
+
+
 def publish(topic: str, dup: bool, qos: int, retain: bool, payload: bytes, packet_id: Optional[int] = None):
     """Build a PUBLISH packet.
     """

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -40,17 +40,11 @@ def encode_remainining_length(remaining_length: int) -> bytes:
     :returns: Encoded remaining length
     :rtype: bytes
     """
-    encoding = True
-    encoded_bytes = bytearray()
-    encoded_byte = 0
-    while encoding:
-        encoded_byte = remaining_length % 128
-        remaining_length //= 128
-        if remaining_length:
-            encoded_byte |= 0x80
-        else:
-            encoding = False
-        encoded_bytes.append(encoded_byte)
+    encoded_bytes = []
+    while remaining_length >= 128:
+        remaining_length, encoded_byte = divmod(remaining_length, 128)
+        encoded_bytes.append(encoded_byte | 0x80)
+    encoded_bytes.append(remaining_length)
     return bytes(encoded_bytes)
 
 

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -6,7 +6,6 @@ import struct
 from typing import Union # pylint: disable=unused-import
 
 import attr
-import six
 
 from . import _constants
 
@@ -15,8 +14,8 @@ _CONNECT_REMAINING_LENGTH = 10
 PROTOCOL_NAME = 'MQTT'.encode('utf-8')
 
 def _check_none_or_text(_instance, attribute, value):
-    if value is not None and not isinstance(value, six.text_type):
-        raise TypeError('{} must be None or text'.format(attribute))
+    if value is not None and not isinstance(value, str):
+        raise TypeError('{} must be None or str'.format(attribute))
 
 def _check_will_message(instance, _attribute, value):
     if value is not None and instance.will_topic is None:
@@ -58,8 +57,8 @@ def encode_remainining_length(remaining_length):
 
 def encode_string(text):
     """Encode a string as per MQTT spec: two byte length, UTF-8 data"""
-    if not isinstance(text, six.text_type):
-        raise TypeError('text must be unicode')
+    if not isinstance(text, str):
+        raise TypeError('text must be str')
 
     encoded_text = text.encode('utf-8')
     text_len = struct.pack('!H', len(encoded_text))
@@ -156,9 +155,7 @@ def connect(client_id, keepalive=60, connect_spec=None):
 
     remaining_length = 0
 
-    msg = six.int2byte(
-        (_constants.MQTT_PACKET_CONNECT << 4),
-    )
+    msg = (_constants.MQTT_PACKET_CONNECT << 4).to_bytes(1, "big")
 
     parts = [msg]
 
@@ -216,7 +213,7 @@ class SubscriptionSpec(object):
     A data class for a topicfilter qos pair.
     """
     topicfilter = attr.ib(
-        validator=attr.validators.instance_of(six.text_type),
+        validator=attr.validators.instance_of(str),
     )
 
     qos = attr.ib(
@@ -258,9 +255,7 @@ def subscribe(packetid, topicspecs):
     for spec in topicspecs:
         remaining_len += spec.remaining_len()
 
-    msg = six.int2byte(
-        (_constants.MQTT_PACKET_SUBSCRIBE << 4) | 0x02,
-    )
+    msg = ((_constants.MQTT_PACKET_SUBSCRIBE << 4) | 0x02).to_bytes(1, "big")
 
     encoded_specs = [msg]
     encoded_specs.append(encode_remainining_length(remaining_len))
@@ -290,7 +285,7 @@ def publish(topic, dup, qos, retain, payload, packet_id=None):
     if qos not in _constants.VALID_QOS:
         raise ValueError('QoS must be 0, 1, or 2')
 
-    if not isinstance(topic, six.text_type):
+    if not isinstance(topic, str):
         raise ValueError('Qos must be 0, 1, or 2')
 
     if qos > 0 and packet_id is None:
@@ -317,7 +312,7 @@ def publish(topic, dup, qos, retain, payload, packet_id=None):
     byte1 |= qos << 1
     byte1 |= int(retain)
     return b''.join((
-        six.int2byte(byte1),
+        byte1.to_bytes(1, "big"),
         rl,
         encoded_topic,
         encoded_packet_id,
@@ -337,7 +332,7 @@ def unsubscribe(packet_id, topics):
     for et in encoded_topics:
         remaining_len += len(et)
 
-    parts = [six.int2byte((_constants.MQTT_PACKET_UNSUBSCRIBE << 4) | 0x1)]
+    parts = [((_constants.MQTT_PACKET_UNSUBSCRIBE << 4) | 0x1).to_bytes(1, "big")]
     parts.append(encode_remainining_length(remaining_len))
     parts.append(encoded_packet_id)
     parts.extend(encoded_topics)

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -54,7 +54,7 @@ def encode_string(text):
         raise TypeError('text must be str')
 
     encoded_text = text.encode('utf-8')
-    text_len = struct.pack('!H', len(encoded_text))
+    text_len = len(encoded_text).to_bytes(2, 'big')
     return b''.join([text_len, encoded_text])
 
 
@@ -227,9 +227,9 @@ class SubscriptionSpec(object):
     def to_bytes(self):
         """Encode this spec as bytes"""
         return b''.join([
-            struct.pack('!H', len(self._encoded)),
+            len(self._encoded).to_bytes(2, 'big'),
             self._encoded,
-            struct.pack('!B', self.qos)
+            self.qos.to_bytes(1, 'big'),
         ])
 
 
@@ -252,7 +252,7 @@ def subscribe(packetid, topicspecs):
 
     encoded_specs = [msg]
     encoded_specs.append(encode_remainining_length(remaining_len))
-    encoded_specs.append(struct.pack('!H', packetid))
+    encoded_specs.append(packetid.to_bytes(2, 'big'))
     encoded_specs.extend(
         [s.to_bytes() for s in topicspecs]
     )
@@ -279,20 +279,21 @@ def publish(topic: str, dup: bool, qos: int, retain: bool, payload: bytes, packe
     if not isinstance(topic, str):
         raise ValueError('Qos must be 0, 1, or 2')
 
-    if qos > 0 and packet_id is None:
-        raise ValueError('QoS of 1 or 2 must have a packet id')
-
-    if qos == 0 and dup:
-        raise ValueError('Dup must not be set on QoS of 0')
-
     if not isinstance(payload, bytes):
         raise TypeError('Payload must be bytes')
 
+    if qos == 0:
+        encoded_packet_id = b''
+        if dup:
+            raise ValueError('Dup must not be set on QoS of 0')
+    elif packet_id is None:
+        raise ValueError('QoS of 1 or 2 must have a packet id')
+    else:
+        encoded_packet_id = packet_id.to_bytes(2, 'big')
+
     remaining_len = len(payload)
-    encoded_packet_id = b''
     if qos > 0:
         remaining_len += _constants.PACKET_ID_LEN
-        encoded_packet_id = struct.pack('!H', packet_id)
 
     encoded_topic = encode_string(topic)
     remaining_len += len(encoded_topic)
@@ -317,7 +318,7 @@ def unsubscribe(packet_id: int, topics: list[str]) -> bytes:
         raise ValueError('At least one topic must be specified')
 
     remaining_len = 2
-    encoded_packet_id = struct.pack('!H', packet_id)
+    encoded_packet_id = packet_id.to_bytes(2, 'big')
     encoded_topics = [encode_string(t) for t in topics]
     for et in encoded_topics:
         remaining_len += len(et)

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -3,7 +3,7 @@ Copyright 2018 Jason Litzinger
 See LICENSE for details.
 """
 import struct
-from typing import Union # pylint: disable=unused-import
+from typing import Optional
 
 import attr
 
@@ -34,8 +34,7 @@ def _check_will_qos(instance, _attribute, value):
         raise ValueError('Will QOS requires topic/message')
 
 
-def encode_remainining_length(remaining_length):
-    # type: (int) -> bytes
+def encode_remainining_length(remaining_length: int) -> bytes:
     """Encode the remaining length for the packet.
 
     :returns: Encoded remaining length
@@ -267,8 +266,7 @@ def subscribe(packetid, topicspecs):
     return b''.join(encoded_specs)
 
 
-def disconnect():
-    # type: () -> bytes
+def disconnect() -> bytes:
     """Build a DISCONNECT packet."""
     return struct.pack(
         "!BB",
@@ -277,8 +275,7 @@ def disconnect():
     )
 
 
-def publish(topic, dup, qos, retain, payload, packet_id=None):
-    # type: (str, bool, int, bool, bytes, Union[None,int]) -> bytes
+def publish(topic: str, dup: bool, qos: int, retain: bool, payload: bytes, packet_id: Optional[int] = None):
     """Build a PUBLISH packet.
     """
     #remaining_len = (topiclen after encoding + 2) + (2 | 0 if packetid) + payload_len
@@ -320,8 +317,7 @@ def publish(topic, dup, qos, retain, payload, packet_id=None):
     ))
 
 
-def unsubscribe(packet_id, topics):
-    # (int, List[str]) -> bytes
+def unsubscribe(packet_id: int, topics: list[str]) -> bytes:
     """Build an UNSUBSCRIBE message for the specified topics."""
     if not topics:
         raise ValueError('At least one topic must be specified')

--- a/src/mqttpacket/v311/_builders.py
+++ b/src/mqttpacket/v311/_builders.py
@@ -14,7 +14,7 @@ from ._packet import dataclass
 
 _CONNECT_REMAINING_LENGTH = 10
 
-PROTOCOL_NAME = 'MQTT'.encode('utf-8')
+PROTOCOL_NAME = b'MQTT'
 
 def _check_none_or_text(_instance, attribute, value):
     if value is not None and not isinstance(value, str):
@@ -56,7 +56,7 @@ def encode_string(text):
     if not isinstance(text, str):
         raise TypeError('text must be str')
 
-    encoded_text = text.encode('utf-8')
+    encoded_text = text.encode()
     text_len = len(encoded_text).to_bytes(2, 'big')
     return b''.join([text_len, encoded_text])
 
@@ -197,7 +197,7 @@ class SubscriptionSpec:
     def __post_init__(self):
         if not 0 <= self.qos < 3:
             raise ValueError('qos must be 0 <= qos < 3')
-        self._encoded = self.topicfilter.encode('utf-8')
+        self._encoded = self.topicfilter.encode()
 
     def remaining_len(self):
         """

--- a/src/mqttpacket/v311/_packet.py
+++ b/src/mqttpacket/v311/_packet.py
@@ -3,6 +3,7 @@ Copyright 2018 Jason Litzinger
 See LICENSE for details
 """
 import sys
+from abc import ABC
 from dataclasses import dataclass, field
 
 from typing import Optional
@@ -17,8 +18,12 @@ if sys.version_info < (3, 10):
         return _dataclass(cls, **kwargs)
 
 
+class MQTTPacket(ABC):
+    pass
+
+
 @dataclass
-class ConnackPacket:
+class ConnackPacket(MQTTPacket):
     """Parsed CONNACK packet
 
     :ivar return_code: Return code from the connect operation.
@@ -33,7 +38,7 @@ class ConnackPacket:
 
 
 @dataclass
-class SubackPacket:
+class SubackPacket(MQTTPacket):
     """Parsed SUBACK packet
 
     """
@@ -43,7 +48,7 @@ class SubackPacket:
 
 
 @dataclass(slots=True)
-class PublishPacket:
+class PublishPacket(MQTTPacket):
     """
     Packet representing an incoming publish message.
     """
@@ -60,7 +65,7 @@ class PublishPacket:
 
 
 @dataclass(slots=True)
-class DisconnectPacket:
+class DisconnectPacket(MQTTPacket):
     """
     Packet representing a disconnect
 
@@ -71,7 +76,7 @@ class DisconnectPacket:
 
 
 @dataclass(slots=True)
-class PubackPacket:
+class PubackPacket(MQTTPacket):
     """
     Class representing a PUBACK packet.
 
@@ -82,7 +87,7 @@ class PubackPacket:
 
 
 @dataclass(slots=True)
-class PingrespPacket:
+class PingrespPacket(MQTTPacket):
     """
     Class representing a PINGRESP packet.  In
     generally this can be created once and reused.

--- a/src/mqttpacket/v311/_packet.py
+++ b/src/mqttpacket/v311/_packet.py
@@ -2,12 +2,23 @@
 Copyright 2018 Jason Litzinger
 See LICENSE for details
 """
-import attr
+import sys
+from dataclasses import dataclass, field
+
+from typing import Optional
 
 from . import _constants
 
-@attr.s
-class ConnackPacket(object):
+if sys.version_info < (3, 10):
+    from functools import wraps
+    from dataclasses import dataclass as _dataclass
+    @wraps(_dataclass)
+    def dataclass(cls=None, /, *, slots=False, **kwargs):
+        return _dataclass(cls, **kwargs)
+
+
+@dataclass
+class ConnackPacket:
     """Parsed CONNACK packet
 
     :ivar return_code: Return code from the connect operation.
@@ -16,63 +27,64 @@ class ConnackPacket(object):
 
     :ivar pkt_type: MQTT_PACKET_CONNACK
     """
-    return_code = attr.ib()
-    session_present = attr.ib()
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_CONNACK)
+    return_code: int
+    session_present: int
+    pkt_type: int = _constants.MQTT_PACKET_CONNACK
 
 
-@attr.s
-class SubackPacket(object):
+@dataclass
+class SubackPacket:
     """Parsed SUBACK packet
 
     """
-    packet_id = attr.ib()
-    return_codes = attr.ib()
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_SUBACK)
+    packet_id: int
+    return_codes: list[int]
+    pkt_type: int = _constants.MQTT_PACKET_SUBACK
 
 
-@attr.s(slots=True)
-class PublishPacket(object):
+@dataclass(slots=True)
+class PublishPacket:
     """
     Packet representing an incoming publish message.
     """
-    dup = attr.ib()
-    qos = attr.ib(
-        validator=attr.validators.in_(_constants.VALID_QOS)
-    )
-    retain = attr.ib()
-    topic = attr.ib()
-    packetid = attr.ib()
-    payload = attr.ib()
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_PUBLISH)
+    dup: bool
+    qos: int
+    retain: bool
+    topic: str
+    packetid: Optional[int]
+    payload: bytes
+    pkt_type: int = _constants.MQTT_PACKET_PUBLISH
+
+    def __post_init__(self):
+        assert self.qos in _constants.VALID_QOS
 
 
-@attr.s(slots=True)
-class DisconnectPacket(object):
+@dataclass(slots=True)
+class DisconnectPacket:
     """
     Packet representing a disconnect
 
     :ivar reserved: Reserved bits from the packet.
     """
-    reserved = attr.ib()
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_DISCONNECT)
+    reserved: int
+    pkt_type: int = _constants.MQTT_PACKET_DISCONNECT
 
 
-@attr.s(slots=True)
-class PubackPacket(object):
+@dataclass(slots=True)
+class PubackPacket:
     """
     Class representing a PUBACK packet.
 
     :ivar packet_id: The packet identifier being ack'd.
     """
-    packet_id = attr.ib()
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_PUBACK)
+    packet_id: int
+    pkt_type: int = _constants.MQTT_PACKET_PUBACK
 
 
-@attr.s(slots=True)
-class PingrespPacket(object):
+@dataclass(slots=True)
+class PingrespPacket:
     """
     Class representing a PINGRESP packet.  In
     generally this can be created once and reused.
     """
-    pkt_type = attr.ib(default=_constants.MQTT_PACKET_PINGRESP)
+    pkt_type: int = _constants.MQTT_PACKET_PINGRESP

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -5,7 +5,6 @@ See LICENSE for details.
 A parser should either consume all packet data, or raise and error.
 
 """
-from __future__ import absolute_import
 from typing import (  # pylint: disable=unused-import
     ByteString,
     List,

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -98,7 +98,7 @@ def parse_publish(data: AnyBytes, remaining_length: int, variable_begin: int) ->
 
     topic_len = (data[variable_begin] << 8) | data[variable_begin+1]
     variable_begin += 2
-    topic = data[variable_begin:variable_begin+topic_len].decode('utf-8')
+    topic = data[variable_begin:variable_begin+topic_len].decode()
     # Check for wildcard chars
     variable_begin += topic_len
     packetid = None

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -13,6 +13,7 @@ from typing import (
 
 
 from . import _packet, _errors, _constants
+from ._packet import MQTTPacket
 
 AnyBytes = Union[bytes, bytearray]
 
@@ -26,8 +27,6 @@ def parse_connack(data: AnyBytes, remaining_length: int, variable_begin: int) ->
     :raises: MQTTParseError if packet is malformed
     :returns: length consumed, return code and session_present flag from the
         CONNACK packet.
-
-    :rtype: int
 
     """
     if remaining_length != 2:
@@ -47,14 +46,14 @@ def parse_connack(data: AnyBytes, remaining_length: int, variable_begin: int) ->
 
 _PINGRESP = _packet.PingrespPacket()
 
-def parse_pingresp(_data, _length, _variable_begin):
+def parse_pingresp(_data, _length, _variable_begin) -> _packet.PingrespPacket:
     """
     Parse a PINGRESP, consume and discard.
     """
     return _PINGRESP
 
 
-def parse_suback(data, remaining_length, variable_begin):
+def parse_suback(data, remaining_length, variable_begin) -> _packet.SubackPacket:
     """
     Parse a SUBACK packet.
 
@@ -121,7 +120,7 @@ def parse_disconnect(data: AnyBytes, _remaining_length: int, _offset: int) -> _p
     return _packet.DisconnectPacket(data[0] & 0x0f)
 
 
-def parse_puback(data, remaining_length, offset):
+def parse_puback(data, remaining_length, offset) -> _packet.PubackPacket:
     """Parse a puback from a payload."""
     if remaining_length != 2:
         raise _errors.MQTTInvalidPacketError(
@@ -163,7 +162,7 @@ def check_total_len(data: AnyBytes, offset: int, remaining_length: int, variable
     return (len(data) - offset) == (remaining_length + 1 + size_rem_len)
 
 
-def parse(data: AnyBytes) -> tuple[int, list]:
+def parse(data: AnyBytes) -> tuple[int, list[MQTTPacket]]:
     """Parse packets from data.
 
     :param data: Data to parse into MQTT packets
@@ -178,7 +177,7 @@ def parse(data: AnyBytes) -> tuple[int, list]:
     return n, output
 
 
-def parse_into(data: AnyBytes, output: list) -> int:
+def parse_into(data: AnyBytes, output: list[MQTTPacket]) -> int:
     """Parse packets from data.
 
     :param data: Data to parse into MQTT packets

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -162,7 +162,23 @@ def check_total_len(data: AnyBytes, offset: int, remaining_length: int, variable
     size_rem_len = variable_begin - offset - 1
     return (len(data) - offset) == (remaining_length + 1 + size_rem_len)
 
-def parse(data: AnyBytes, output: list) -> int:
+
+def parse(data: AnyBytes) -> tuple[int, list]:
+    """Parse packets from data.
+
+    :param data: Data to parse into MQTT packets
+
+    :param output: Output list for storing parsed packets.
+
+    :returns: (number of bytes from data consumed, list of parsed packets)
+
+    """
+    output: list = []
+    n: int = parse_into(data, output)
+    return n, output
+
+
+def parse_into(data: AnyBytes, output: list) -> int:
     """Parse packets from data.
 
     :param data: Data to parse into MQTT packets

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -159,7 +159,25 @@ _MAX_REMAINING_LENGTH = 268435455
 def check_total_len(data: AnyBytes, offset: int, remaining_length: int, variable_begin: int) -> bool:
     """Verify enough data is available"""
     size_rem_len = variable_begin - offset - 1
-    return (len(data) - offset) == (remaining_length + 1 + size_rem_len)
+    return offset + 1 + size_rem_len + remaining_length <= len(data)
+
+
+def parse_one(data: AnyBytes) -> MQTTPacket:
+    """Parse exactly one packet from data. This should only be used
+    if the MQTT packets are pre-framed.
+    :param data: Data to parse into an MQTT packet
+
+    :raises MQTTParseError: if data doesn't contain exactly one complete packet
+
+    :returns: one parsed packet
+
+    """
+    n, pkt = parse(data)
+    if n != len(data) or len(pkt) != 1:
+        raise _errors.MQTTParseError(
+            f"Data was not parsed into exactly one packet ({n} of {len(data)} bytes parsed)",
+            n, len(data))
+    return pkt[0]
 
 
 def parse(data: AnyBytes) -> tuple[int, list[MQTTPacket]]:
@@ -200,6 +218,8 @@ def parse_into(data: AnyBytes, output: list[MQTTPacket]) -> int:
         parsing_len = True
         nb = 0
         while parsing_len:
+            if variable_begin >= len(data):
+                return consumed
             remaining_length += (data[variable_begin] & 127) * _MULTIPLIERS[nb]
             nb += 1
             parsing_len = (

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -8,11 +8,15 @@ A parser should either consume all packet data, or raise and error.
 from typing import (
     Any,
     Callable,
+    Union,
 )
+
 
 from . import _packet, _errors, _constants
 
-def parse_connack(data: bytearray, remaining_length: int, variable_begin: int) -> _packet.ConnackPacket:
+AnyBytes = Union[bytes, bytearray]
+
+def parse_connack(data: AnyBytes, remaining_length: int, variable_begin: int) -> _packet.ConnackPacket:
     """Parse a CONNACK packet
 
     :param data: Data to parse
@@ -74,11 +78,11 @@ def parse_suback(data, remaining_length, variable_begin):
 
 
 
-def parse_publish(data: bytearray, remaining_length: int, variable_begin: int) -> _packet.PublishPacket:
+def parse_publish(data: AnyBytes, remaining_length: int, variable_begin: int) -> _packet.PublishPacket:
     """Parse a PUBLISH packet.
 
     :param data: Incoming data to parse.
-    :type data: bytearray
+    :type data: AnyBytes
 
     :param variable_begin: Offset of start of variable length header
 
@@ -112,7 +116,7 @@ def parse_publish(data: bytearray, remaining_length: int, variable_begin: int) -
     )
 
 
-def parse_disconnect(data: bytearray, _remaining_length: int, _offset: int) -> _packet.DisconnectPacket:
+def parse_disconnect(data: AnyBytes, _remaining_length: int, _offset: int) -> _packet.DisconnectPacket:
     """Parse a DISCONNECT packet and validate"""
     return _packet.DisconnectPacket(data[0] & 0x0f)
 
@@ -128,11 +132,11 @@ def parse_puback(data, remaining_length, offset):
     )
 
 
-def _null_parse(_data: bytearray, _remaining_length: int, _offset: int) -> None:
+def _null_parse(_data: AnyBytes, _remaining_length: int, _offset: int) -> None:
     """Empty parser"""
 
 
-PARSERS: dict[int, Callable[[bytearray, int, int], Any]] = {
+PARSERS: dict[int, Callable[[AnyBytes, int, int], Any]] = {
     _constants.MQTT_PACKET_CONNECT: _null_parse,
     _constants.MQTT_PACKET_CONNACK: parse_connack,
     _constants.MQTT_PACKET_PUBLISH: parse_publish,
@@ -153,12 +157,12 @@ PARSERS: dict[int, Callable[[bytearray, int, int], Any]] = {
 _MULTIPLIERS = (1, 128, 128 * 128, 128 * 128 * 128, 0)
 _MAX_REMAINING_LENGTH = 268435455
 
-def check_total_len(data: bytes, offset: int, remaining_length: int, variable_begin: int) -> bool:
+def check_total_len(data: AnyBytes, offset: int, remaining_length: int, variable_begin: int) -> bool:
     """Verify enough data is available"""
     size_rem_len = variable_begin - offset - 1
     return (len(data) - offset) == (remaining_length + 1 + size_rem_len)
 
-def parse(data: bytes, output: list) -> int:
+def parse(data: AnyBytes, output: list) -> int:
     """Parse packets from data.
 
     :param data: Data to parse into MQTT packets
@@ -168,8 +172,8 @@ def parse(data: bytes, output: list) -> int:
     :returns: number of bytes from data consumed
 
     """
-    if not isinstance(data, bytearray):
-        raise TypeError("data must be a bytearray")
+    if not isinstance(data, (bytes, bytearray)):
+        raise TypeError("data must be a bytes or bytearray")
 
     consumed = 0
     offset = 0

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -5,18 +5,14 @@ See LICENSE for details.
 A parser should either consume all packet data, or raise and error.
 
 """
-from typing import (  # pylint: disable=unused-import
-    ByteString,
-    List,
+from typing import (
     Any,
     Callable,
-    Dict
 )
 
 from . import _packet, _errors, _constants
 
-def parse_connack(data, remaining_length, variable_begin):
-    # type: (bytearray, int, int) -> _packet.ConnackPacket
+def parse_connack(data: bytearray, remaining_length: int, variable_begin: int) -> _packet.ConnackPacket:
     """Parse a CONNACK packet
 
     :param data: Data to parse
@@ -78,8 +74,7 @@ def parse_suback(data, remaining_length, variable_begin):
 
 
 
-def parse_publish(data, remaining_length, variable_begin):
-    # type: (bytearray, int, int) -> _packet.PublishPacket
+def parse_publish(data: bytearray, remaining_length: int, variable_begin: int) -> _packet.PublishPacket:
     """Parse a PUBLISH packet.
 
     :param data: Incoming data to parse.
@@ -117,8 +112,7 @@ def parse_publish(data, remaining_length, variable_begin):
     )
 
 
-def parse_disconnect(data, _remaining_length, _offset):
-    # type: (bytearray, int, int) -> _packet.DisconnectPacket
+def parse_disconnect(data: bytearray, _remaining_length: int, _offset: int) -> _packet.DisconnectPacket:
     """Parse a DISCONNECT packet and validate"""
     return _packet.DisconnectPacket(data[0] & 0x0f)
 
@@ -134,12 +128,11 @@ def parse_puback(data, remaining_length, offset):
     )
 
 
-def _null_parse(_data, _remaining_length, _offset):
-    # type: (bytearray, int, int) -> None
+def _null_parse(_data: bytearray, _remaining_length: int, _offset: int) -> None:
     """Empty parser"""
 
 
-PARSERS = {
+PARSERS: dict[int, Callable[[bytearray, int, int], Any]] = {
     _constants.MQTT_PACKET_CONNECT: _null_parse,
     _constants.MQTT_PACKET_CONNACK: parse_connack,
     _constants.MQTT_PACKET_PUBLISH: parse_publish,
@@ -154,20 +147,18 @@ PARSERS = {
     _constants.MQTT_PACKET_PINGREQ: _null_parse,
     _constants.MQTT_PACKET_PINGRESP: parse_pingresp,
     _constants.MQTT_PACKET_DISCONNECT: parse_disconnect,
-} # type: Dict[int, Callable[[bytearray, int, int], Any]]
+}
 
 
 _MULTIPLIERS = (1, 128, 128 * 128, 128 * 128 * 128, 0)
 _MAX_REMAINING_LENGTH = 268435455
 
-def check_total_len(data, offset, remaining_length, variable_begin):
-    # type: (ByteString, int, int, int) -> bool
+def check_total_len(data: bytes, offset: int, remaining_length: int, variable_begin: int) -> bool:
     """Verify enough data is available"""
     size_rem_len = variable_begin - offset - 1
     return (len(data) - offset) == (remaining_length + 1 + size_rem_len)
 
-def parse(data, output):
-    # type: (ByteString, List[Any]) -> int
+def parse(data: bytes, output: list) -> int:
     """Parse packets from data.
 
     :param data: Data to parse into MQTT packets

--- a/src/mqttpacket/v311/_parsing.py
+++ b/src/mqttpacket/v311/_parsing.py
@@ -107,9 +107,9 @@ def parse_publish(data: AnyBytes, remaining_length: int, variable_begin: int) ->
         variable_begin += 2
 
     return _packet.PublishPacket(
-        (flags & 0x08) >> 3,
+        bool((flags & 0x08) >> 3),
         qos,
-        flags & 0x1,
+        bool(flags & 0x1),
         topic,
         packetid,
         data[variable_begin:end_packet]

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -77,22 +77,6 @@ def test_default_spec():
     assert cs.flags() == 0x02
 
 
-def test_will_must_be_unicode():
-    """
-    Will topic and will message must be unicode.
-    """
-    with pytest.raises(TypeError):
-        mqttpacket.ConnectSpec(
-            will_topic=b'foo',
-            will_message=u'bar'
-        )
-
-    with pytest.raises(TypeError):
-        mqttpacket.ConnectSpec(
-            will_topic=u'biz',
-            will_message=b'baz'
-        )
-
 def test_will_qos_values():
     """
     Will QOS can only be 0 - 2

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -365,3 +365,10 @@ def test_unsubscribe_requires_one():
     """
     with pytest.raises(ValueError):
         mqttpacket.unsubscribe(123, [])
+
+
+def test_puback():
+    msg = mqttpacket.puback(456)
+    assert msg[:1] == b'\x40'
+    assert msg[1] == 2
+    assert msg[2:] == (456).to_bytes(2, 'big')

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -15,13 +15,13 @@ def test_connect_basic():
     A connect packet with only a client id is properly constructed.
     """
     expect = bytes.fromhex('101000044d5154540402003c000474657374')
-    packet = mqttpacket.connect(u'test')
+    packet = mqttpacket.connect('test')
     assert packet == expect
     assert isinstance(packet, bytes)
     assert len(packet) == 18
     assert packet[0] == 16
     assert packet[9] == 0x02
-    assert packet[14:].decode('utf-8') == u'test'
+    assert packet[14:].decode() == 'test'
 
 
 def test_will_requirements():
@@ -30,12 +30,12 @@ def test_will_requirements():
     """
     with pytest.raises(ValueError):
         mqttpacket.ConnectSpec(
-            will_topic=u'foo',
+            will_topic='foo',
         )
 
     with pytest.raises(ValueError):
         mqttpacket.ConnectSpec(
-            will_message=u'my message',
+            will_message='my message',
         )
 
 
@@ -44,26 +44,26 @@ def test_valid_will():
     A valid will topic/message spec sets flags and payload.
     """
     cs = mqttpacket.ConnectSpec(
-        will_topic=u'my_will_topic',
-        will_message=u'my_will_message',
+        will_topic='my_will_topic',
+        will_message='my_will_message',
         will_qos=1,
     )
 
-    wt = u'my_will_topic'
-    wm = u'my_will_message'
+    wt = 'my_will_topic'
+    wm = 'my_will_message'
     assert cs.will_topic == wt
     assert cs.will_message == wm
     assert cs.flags() == 0x0e
     assert len(cs.payload()) == 32
 
     cs = mqttpacket.ConnectSpec(
-        will_topic=u'wt2',
-        will_message=u'wm2',
+        will_topic='wt2',
+        will_message='wm2',
         will_qos=2,
     )
 
-    assert cs.will_topic == u'wt2'
-    assert cs.will_message == u'wm2'
+    assert cs.will_topic == 'wt2'
+    assert cs.will_message == 'wm2'
     assert cs.flags() == 0x16
 
 
@@ -83,20 +83,20 @@ def test_will_qos_values():
     """
     with pytest.raises(ValueError):
         mqttpacket.ConnectSpec(
-            will_topic=u'biz',
-            will_message=u'baz',
+            will_topic='biz',
+            will_message='baz',
             will_qos=3
         )
 
     mqttpacket.ConnectSpec(
-        will_topic=u'my_will_topic',
-        will_message=u'my_will_message',
+        will_topic='my_will_topic',
+        will_message='my_will_message',
         will_qos=1
     )
 
     mqttpacket.ConnectSpec(
-        will_topic=u'my_will_topic',
-        will_message=u'my_will_message',
+        will_topic='my_will_topic',
+        will_message='my_will_message',
         will_qos=2
     )
 
@@ -106,16 +106,16 @@ def test_connect_with_spec():
     A valid connect spec is properly encoded.
     """
     cs = mqttpacket.ConnectSpec(
-        will_topic=u'my_will_topic',
-        will_message=u'my_will_message',
+        will_topic='my_will_topic',
+        will_message='my_will_message',
         will_qos=1,
     )
-    packet = mqttpacket.connect(u'test', connect_spec=cs)
+    packet = mqttpacket.connect('test', connect_spec=cs)
     assert isinstance(packet, bytes)
     assert len(packet) == 50
     assert packet[0] == 16
     assert packet[9] == 0x0e
-    assert packet[14:18].decode('utf-8') == u'test'
+    assert packet[14:18].decode() == 'test'
 
 
 def test_build_subscription_multiple():
@@ -125,8 +125,8 @@ def test_build_subscription_multiple():
     This example is from the MQTT specification.
     """
     specs = [
-        mqttpacket.SubscriptionSpec(u'a/b', 0x01),
-        mqttpacket.SubscriptionSpec(u'c/d', 0x02),
+        mqttpacket.SubscriptionSpec('a/b', 0x01),
+        mqttpacket.SubscriptionSpec('c/d', 0x02),
     ]
     packet = mqttpacket.subscribe(10, specs)
     assert isinstance(packet, bytes)
@@ -134,10 +134,10 @@ def test_build_subscription_multiple():
     assert packet[1] == 14
     assert packet[2] << 8 | packet[3] == 10
     assert packet[4] << 8 | packet[5] == 3
-    assert packet[6:9].decode('utf-8') == u'a/b'
+    assert packet[6:9].decode() == 'a/b'
     assert packet[9] == 0x01
     assert packet[10] << 8 | packet[11] == 3
-    assert packet[12:15].decode('utf-8') == u'c/d'
+    assert packet[12:15].decode() == 'c/d'
     assert packet[15] == 0x02
 
 
@@ -148,7 +148,7 @@ def test_build_subscription_single():
     This example is from the MQTT specification.
     """
     specs = [
-        mqttpacket.SubscriptionSpec(u'test/1', 0x00),
+        mqttpacket.SubscriptionSpec('test/1', 0x00),
     ]
     packet = mqttpacket.subscribe(10, specs)
     assert isinstance(packet, bytes)
@@ -156,7 +156,7 @@ def test_build_subscription_single():
     assert packet[1] == 11
     assert packet[2] << 8 | packet[3] == 10
     assert packet[4] << 8 | packet[5] == 6
-    assert packet[6:12].decode('utf-8') == u'test/1'
+    assert packet[6:12].decode() == 'test/1'
     assert packet[12] == 0x00
 
 
@@ -165,7 +165,7 @@ def test_subscription_spec_multibyte():
     A topic with multibyte characters encoded as UTF uses
     the encoded length.
     """
-    topic = u'super€'
+    topic = 'super€'
     spec = mqttpacket.SubscriptionSpec(
         topic,
         0
@@ -225,10 +225,10 @@ def test_publish():
     """
     A valid PUBLISH packet is successfully decoded.
     """
-    payload = {u'test': u'test'}
-    payload_str = json.dumps(payload).encode('utf-8')
+    payload = {'test': 'test'}
+    payload_str = json.dumps(payload).encode()
     publish = mqttpacket.publish(
-        u'test',
+        'test',
         False,
         0,
         True,
@@ -247,20 +247,20 @@ def test_publish_nonzero_qos_requires_packetid():
     """
     with pytest.raises(ValueError):
         mqttpacket.publish(
-            u'test',
+            'test',
             False,
             1,
             True,
-            u'foo'.encode('utf-8')
+            b'foo'
         )
 
     with pytest.raises(ValueError):
         mqttpacket.publish(
-            u'test',
+            'test',
             False,
             2,
             True,
-            u'foo'.encode('utf-8')
+            b'foo'
         )
 
 
@@ -269,11 +269,11 @@ def test_publish_qos_1():
     A publish with a QoS of 1 and a packet id are successfully encoded.
     """
     publish = mqttpacket.publish(
-        u'test',
+        'test',
         False,
         1,
         True,
-        u'foo'.encode('utf-8'),
+        b'foo',
         packet_id=255
     )
     expect = bytes.fromhex('330b00047465737400ff666f6f')
@@ -285,11 +285,11 @@ def test_publish_qos_2():
     A publish with a QoS of 2 and a packet id are successfully encoded.
     """
     publish = mqttpacket.publish(
-        u'test',
+        'test',
         False,
         2,
         False,
-        u'foo'.encode('utf-8'),
+        b'foo',
         packet_id=256
     )
     expect = bytes.fromhex('340b0004746573740100666f6f')
@@ -301,11 +301,11 @@ def test_publish_dup():
     A publish with dup set is successfully encoded
     """
     publish = mqttpacket.publish(
-        u'test',
+        'test',
         True,
         1,
         False,
-        u'foo'.encode('utf-8'),
+        b'foo',
         packet_id=256
     )
     expect = bytes.fromhex('3a0b0004746573740100666f6f')
@@ -318,11 +318,11 @@ def test_publish_dup_requires_qos():
     """
     with pytest.raises(ValueError):
         mqttpacket.publish(
-            u'test',
+            'test',
             True,
             0,
             False,
-            u'foo'.encode('utf-8'),
+            b'foo',
             packet_id=256
         )
 
@@ -332,11 +332,11 @@ def test_publish_payload_requires_bytes():
     """
     with pytest.raises(TypeError):
         mqttpacket.publish(
-            u'test',
+            'test',
             False,
             0,
             False,
-            u'foo'
+            'foo'
         )
 
 def test_pingreq():
@@ -349,14 +349,14 @@ def test_unsubscribe():
     """
     An unsubscribe of two topics is successfully built.
     """
-    msg = mqttpacket.unsubscribe(257, [u'a/b', u'c/d'])
+    msg = mqttpacket.unsubscribe(257, ['a/b', 'c/d'])
     assert msg[:1] == b'\xa1'
     assert msg[1] == 12
     assert msg[2:4] == b'\x01\x01'
     assert msg[4:6] == b'\x00\x03'
-    assert msg[6:9] == u'a/b'.encode('utf-8')
+    assert msg[6:9] == b'a/b'
     assert msg[9:11] == b'\x00\x03'
-    assert msg[11:] == u'c/d'.encode('utf-8')
+    assert msg[11:] == b'c/d'
 
 
 def test_unsubscribe_requires_one():

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -6,7 +6,6 @@ See LICENSE for details.
 import binascii
 import json
 
-import six
 import pytest
 
 import mqttpacket.v311 as mqttpacket
@@ -23,8 +22,8 @@ def test_connect_basic():
     assert packet == expect
     assert isinstance(packet, bytes)
     assert len(packet) == 18
-    assert six.indexbytes(packet, 0) == 16
-    assert six.indexbytes(packet, 9) == 0x02
+    assert packet[0] == 16
+    assert packet[9] == 0x02
     assert packet[14:].decode('utf-8') == u'test'
 
 
@@ -133,8 +132,8 @@ def test_connect_with_spec():
     packet = mqttpacket.connect(u'test', connect_spec=cs)
     assert isinstance(packet, bytes)
     assert len(packet) == 50
-    assert six.indexbytes(packet, 0) == 16
-    assert six.indexbytes(packet, 9) == 0x0e
+    assert packet[0] == 16
+    assert packet[9] == 0x0e
     assert packet[14:18].decode('utf-8') == u'test'
 
 
@@ -150,15 +149,15 @@ def test_build_subscription_multiple():
     ]
     packet = mqttpacket.subscribe(10, specs)
     assert isinstance(packet, bytes)
-    assert six.indexbytes(packet, 0) == 0x82
-    assert six.indexbytes(packet, 1) == 14
-    assert six.indexbytes(packet, 2) << 8 | six.indexbytes(packet, 3) == 10
-    assert six.indexbytes(packet, 4) << 8 | six.indexbytes(packet, 5) == 3
+    assert packet[0] == 0x82
+    assert packet[1] == 14
+    assert packet[2] << 8 | packet[3] == 10
+    assert packet[4] << 8 | packet[5] == 3
     assert packet[6:9].decode('utf-8') == u'a/b'
-    assert six.indexbytes(packet, 9) == 0x01
-    assert six.indexbytes(packet, 10) << 8 | six.indexbytes(packet, 11) == 3
+    assert packet[9] == 0x01
+    assert packet[10] << 8 | packet[11] == 3
     assert packet[12:15].decode('utf-8') == u'c/d'
-    assert six.indexbytes(packet, 15) == 0x02
+    assert packet[15] == 0x02
 
 
 def test_build_subscription_single():
@@ -172,12 +171,12 @@ def test_build_subscription_single():
     ]
     packet = mqttpacket.subscribe(10, specs)
     assert isinstance(packet, bytes)
-    assert six.indexbytes(packet, 0) == 0x82
-    assert six.indexbytes(packet, 1) == 11
-    assert six.indexbytes(packet, 2) << 8 | six.indexbytes(packet, 3) == 10
-    assert six.indexbytes(packet, 4) << 8 | six.indexbytes(packet, 5) == 6
+    assert packet[0] == 0x82
+    assert packet[1] == 11
+    assert packet[2] << 8 | packet[3] == 10
+    assert packet[4] << 8 | packet[5] == 6
     assert packet[6:12].decode('utf-8') == u'test/1'
-    assert six.indexbytes(packet, 12) == 0x00
+    assert packet[12] == 0x00
 
 
 def test_subscription_spec_multibyte():
@@ -255,8 +254,8 @@ def test_publish():
         payload_str
     )
     print(binascii.hexlify(publish))
-    assert six.indexbytes(publish, 0) == 49
-    assert six.indexbytes(publish, 1) == 22
+    assert publish[0] == 49
+    assert publish[1] == 22
     expect = binascii.unhexlify(
         b'31160004746573747b2274657374223a202274657374227d'
     )
@@ -379,7 +378,7 @@ def test_unsubscribe():
     """
     msg = mqttpacket.unsubscribe(257, [u'a/b', u'c/d'])
     assert msg[:1] == b'\xa1'
-    assert six.indexbytes(msg, 1) == 12
+    assert msg[1] == 12
     assert msg[2:4] == b'\x01\x01'
     assert msg[4:6] == b'\x00\x03'
     assert msg[6:9] == u'a/b'.encode('utf-8')

--- a/tests/test_building.py
+++ b/tests/test_building.py
@@ -3,7 +3,6 @@
 Copyright 2018 Jason Litzinger
 See LICENSE for details.
 """
-import binascii
 import json
 
 import pytest
@@ -15,9 +14,7 @@ def test_connect_basic():
     """
     A connect packet with only a client id is properly constructed.
     """
-    expect = binascii.unhexlify(
-        b'101000044d5154540402003c000474657374'
-    )
+    expect = bytes.fromhex('101000044d5154540402003c000474657374')
     packet = mqttpacket.connect(u'test')
     assert packet == expect
     assert isinstance(packet, bytes)
@@ -253,12 +250,10 @@ def test_publish():
         True,
         payload_str
     )
-    print(binascii.hexlify(publish))
+    print(publish.hex())
     assert publish[0] == 49
     assert publish[1] == 22
-    expect = binascii.unhexlify(
-        b'31160004746573747b2274657374223a202274657374227d'
-    )
+    expect = bytes.fromhex('31160004746573747b2274657374223a202274657374227d')
     assert publish == expect
 
 
@@ -297,9 +292,7 @@ def test_publish_qos_1():
         u'foo'.encode('utf-8'),
         packet_id=255
     )
-    expect = binascii.unhexlify(
-        b'330b00047465737400ff666f6f'
-    )
+    expect = bytes.fromhex('330b00047465737400ff666f6f')
     assert publish == expect
 
 
@@ -315,9 +308,7 @@ def test_publish_qos_2():
         u'foo'.encode('utf-8'),
         packet_id=256
     )
-    expect = binascii.unhexlify(
-        b'340b0004746573740100666f6f'
-    )
+    expect = bytes.fromhex('340b0004746573740100666f6f')
     assert publish == expect
 
 
@@ -333,9 +324,7 @@ def test_publish_dup():
         u'foo'.encode('utf-8'),
         packet_id=256
     )
-    expect = binascii.unhexlify(
-        b'3a0b0004746573740100666f6f'
-    )
+    expect = bytes.fromhex('3a0b0004746573740100666f6f')
     assert publish == expect
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,7 +2,6 @@
 Copyright 2018 Jason Litzinger
 See LICENSE for details.
 """
-import binascii
 import json
 import pytest
 
@@ -17,10 +16,7 @@ def test_parse_publish_simple():
     """
     A simple publish with QoS of 0 is successfully parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'31150004746573747b2274657374223a2274657374227d')
-    )
+    data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
     msgs = []
     c = _parsing.parse(data, msgs)
     assert len(data) == c
@@ -40,10 +36,7 @@ def test_parse_publish_qos():
     """
     A publish with QoS of 1 is successfully parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'321700047465737400037b2274657374223a2274657374227d')
-    )
+    data = bytes.fromhex('321700047465737400037b2274657374223a2274657374227d')
     msgs = []
     c = _parsing.parse(data, msgs)
     assert len(data) == c
@@ -64,10 +57,7 @@ def test_parse_publish_in_pieces():
     A publish received in chunks is not successfully parsed until all
     data received.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'31150004746573747b2274657374223a2274657374227d')
-    )
+    data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
     msgs = []
 
     assert _parsing.parse(data[:len(data)-1], msgs) == 0
@@ -79,10 +69,7 @@ def test_parse_suback():
     A suback for a single successful subscribe is successfully parsed
     to a single MQTTPacket and all bytes are consumed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'9003000100')
-    )
+    data = bytes.fromhex('9003000100')
     msgs = []
     c = _parsing.parse(data, msgs)
     assert len(data) == c
@@ -96,10 +83,7 @@ def test_parse_connack():
     """
     A CONNACK for a successful connect is successfuly parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'20020000')
-    )
+    data = bytes.fromhex('20020000')
     msgs = []
     c = _parsing.parse(data, msgs)
     assert len(data) == c
@@ -135,10 +119,7 @@ def test_parse_single_byte_remaining_length(capture_len):
     """
     A single byte remaining length is properly parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'31150004746573747b2274657374223a2274657374227d')
-    )
+    data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[0] == 0x15
@@ -148,10 +129,7 @@ def test_parse_only_fixed_header(capture_len):
     """
     A single byte remaining length is properly parsed even it
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'3000')
-    )
+    data = bytes.fromhex('3000')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[0] == 0
@@ -160,18 +138,12 @@ def test_parse_two_byte(capture_len):
     """
     A two byte encoded remaining length is properly parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'30ff7f1a')
-    )
+    data = bytes.fromhex('30ff7f1a')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[0] == 16383
 
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'3080011a')
-    )
+    data = bytes.fromhex('3080011a')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[1] == 128
@@ -180,10 +152,7 @@ def test_parse_three_byte(capture_len):
     """
     A three byte encoded remaining length is properly parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'30ffff7f1a')
-    )
+    data = bytes.fromhex('30ffff7f1a')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[0] == 2097151
@@ -192,10 +161,7 @@ def test_parse_four_byte(capture_len):
     """
     A four byte encoded remaining length is properly parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'30ffffff7f1a')
-    )
+    data = bytes.fromhex('30ffffff7f1a')
     msgs = []
     _parsing.parse(data, msgs)
     assert capture_len[0] == 268435455
@@ -205,10 +171,7 @@ def test_parse_five_byte(capture_len):
     """
     A five byte encoded remaining length is considered an error.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'30ffffffff7f')
-    )
+    data = bytes.fromhex('30ffffffff7f')
     msgs = []
     with pytest.raises(MQTTParseError):
         _parsing.parse(data, msgs)
@@ -236,10 +199,7 @@ def test_parse_puback():
     """
     A valid puback is successfully parsed.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'40023039')
-    )
+    data = bytes.fromhex('40023039')
     msgs = []
     r = _parsing.parse(data, msgs)
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBACK
@@ -249,10 +209,7 @@ def test_parse_puback_invalid():
     """
     A invalid puback raises an error.
     """
-    data = bytearray()
-    data.extend(
-        binascii.unhexlify(b'400130')
-    )
+    data = bytes.fromhex('400130')
     msgs = []
     with pytest.raises(MQTTInvalidPacketError):
         _parsing.parse(data, msgs)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -17,18 +17,16 @@ def test_parse_publish_simple():
     A simple publish with QoS of 0 is successfully parsed.
     """
     data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
-    c, msgs = _parsing.parse(data)
-    assert len(data) == c
-    assert len(msgs) == 1
-    payload = msgs[0].payload
+    msg = _parsing.parse_one(data)
+    payload = msg.payload
     res = json.loads(payload)
     assert res == {"test": "test"}
-    assert msgs[0].packetid is None
-    assert msgs[0].topic == 'test'
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBLISH
-    assert msgs[0].qos == 0
-    assert not msgs[0].dup
-    assert msgs[0].retain
+    assert msg.packetid is None
+    assert msg.topic == 'test'
+    assert msg.pkt_type == _constants.MQTT_PACKET_PUBLISH
+    assert msg.qos == 0
+    assert not msg.dup
+    assert msg.retain
 
 
 def test_parse_publish_qos():
@@ -36,18 +34,16 @@ def test_parse_publish_qos():
     A publish with QoS of 1 is successfully parsed.
     """
     data = bytes.fromhex('321700047465737400037b2274657374223a2274657374227d')
-    c, msgs = _parsing.parse(data)
-    assert len(data) == c
-    assert len(msgs) == 1
-    payload = msgs[0].payload
+    msg = _parsing.parse_one(data)
+    payload = msg.payload
     res = json.loads(payload)
     assert res == {"test": "test"}
-    assert msgs[0].packetid == 3
-    assert msgs[0].topic == 'test'
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBLISH
-    assert msgs[0].qos == 1
-    assert not msgs[0].dup
-    assert not msgs[0].retain
+    assert msg.packetid == 3
+    assert msg.topic == 'test'
+    assert msg.pkt_type == _constants.MQTT_PACKET_PUBLISH
+    assert msg.qos == 1
+    assert not msg.dup
+    assert not msg.retain
 
 
 def test_parse_publish_in_pieces():
@@ -62,18 +58,26 @@ def test_parse_publish_in_pieces():
     assert not msgs
 
 
+def test_parse_one_fails():
+    with pytest.raises(MQTTParseError, match='(4 of 4 bytes parsed)') as exc:
+        _parsing.parse_one(b'\xe0\x00\xe0\x00')
+    with pytest.raises(MQTTParseError, match='(2 of 3 bytes parsed)') as exc:
+        _parsing.parse_one(b'\xe0\x00\xe0')
+    with pytest.raises(MQTTParseError, match='(0 of 1 bytes parsed)') as exc:
+        _parsing.parse_one(b'\x00')
+
+
+
 def test_parse_suback():
     """
     A suback for a single successful subscribe is successfully parsed
     to a single MQTTPacket and all bytes are consumed.
     """
     data = bytes.fromhex('9003000100')
-    c, msgs = _parsing.parse(data)
-    assert len(data) == c
-    assert len(msgs) == 1
-    assert msgs[0].packet_id == 1
-    assert msgs[0].return_codes == [0]
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_SUBACK
+    msg = _parsing.parse_one(data)
+    assert msg.packet_id == 1
+    assert msg.return_codes == [0]
+    assert msg.pkt_type == _constants.MQTT_PACKET_SUBACK
 
 
 def test_parse_connack():
@@ -81,11 +85,10 @@ def test_parse_connack():
     A CONNACK for a successful connect is successfuly parsed.
     """
     data = bytes.fromhex('20020000')
-    c, msgs = _parsing.parse(data)
-    assert len(data) == c
-    assert msgs[0].return_code == 0
-    assert msgs[0].session_present == 0
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_CONNACK
+    msg = _parsing.parse_one(data)
+    assert msg.return_code == 0
+    assert msg.session_present == 0
+    assert msg.pkt_type == _constants.MQTT_PACKET_CONNACK
 
 
 @pytest.fixture(scope='function')
@@ -170,16 +173,16 @@ def test_parse_disconnect():
     """
     A disconnect packet is successfully parsed.
     """
-    r, msgs = _parsing.parse(disconnect())
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_DISCONNECT
+    msg = _parsing.parse_one(b'\xe0\x00')
+    assert msg.pkt_type == _constants.MQTT_PACKET_DISCONNECT
 
 
 def test_parse_pingresp():
     """
     A ping response returns an appropriate packet.
     """
-    r, msgs = _parsing.parse(b'\xd0\x00')
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_PINGRESP
+    msg = _parsing.parse_one(b'\xd0\x00')
+    assert msg.pkt_type == _constants.MQTT_PACKET_PINGRESP
 
 
 def test_parse_puback():
@@ -187,9 +190,9 @@ def test_parse_puback():
     A valid puback is successfully parsed.
     """
     data = bytes.fromhex('40023039')
-    r, msgs = _parsing.parse(data)
-    assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBACK
-    assert msgs[0].packet_id == 12345
+    msg = _parsing.parse_one(data)
+    assert msg.pkt_type == _constants.MQTT_PACKET_PUBACK
+    assert msg.packet_id == 12345
 
 def test_parse_puback_invalid():
     """

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -146,7 +146,7 @@ def test_parse_single_byte_remaining_length(capture_len):
 
 def test_parse_only_fixed_header(capture_len):
     """
-    A single byte remaining length is properly parsed even it 
+    A single byte remaining length is properly parsed even it
     """
     data = bytearray()
     data.extend(
@@ -219,7 +219,7 @@ def test_parse_disconnect():
     A disconnect packet is successfully parsed.
     """
     msgs = []
-    r = _parsing.parse(bytearray(disconnect()), msgs)
+    r = _parsing.parse(disconnect(), msgs)
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_DISCONNECT
 
 
@@ -228,7 +228,7 @@ def test_parse_pingresp():
     A ping response returns an appropriate packet.
     """
     msgs = []
-    r = _parsing.parse(bytearray(b'\xd0\x00'), msgs)
+    r = _parsing.parse(b'\xd0\x00', msgs)
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PINGRESP
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -20,7 +20,7 @@ def test_parse_publish_simple():
     c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert len(msgs) == 1
-    payload = msgs[0].payload.decode('utf-8')
+    payload = msgs[0].payload
     res = json.loads(payload)
     assert res == {"test": "test"}
     assert msgs[0].packetid is None
@@ -39,7 +39,7 @@ def test_parse_publish_qos():
     c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert len(msgs) == 1
-    payload = msgs[0].payload.decode('utf-8')
+    payload = msgs[0].payload
     res = json.loads(payload)
     assert res == {"test": "test"}
     assert msgs[0].packetid == 3

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -17,8 +17,7 @@ def test_parse_publish_simple():
     A simple publish with QoS of 0 is successfully parsed.
     """
     data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
-    msgs = []
-    c = _parsing.parse(data, msgs)
+    c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert len(msgs) == 1
     payload = msgs[0].payload.decode('utf-8')
@@ -37,8 +36,7 @@ def test_parse_publish_qos():
     A publish with QoS of 1 is successfully parsed.
     """
     data = bytes.fromhex('321700047465737400037b2274657374223a2274657374227d')
-    msgs = []
-    c = _parsing.parse(data, msgs)
+    c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert len(msgs) == 1
     payload = msgs[0].payload.decode('utf-8')
@@ -58,9 +56,9 @@ def test_parse_publish_in_pieces():
     data received.
     """
     data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
-    msgs = []
+    c, msgs = _parsing.parse(data[:len(data)-1])
 
-    assert _parsing.parse(data[:len(data)-1], msgs) == 0
+    assert c == 0
     assert not msgs
 
 
@@ -70,8 +68,7 @@ def test_parse_suback():
     to a single MQTTPacket and all bytes are consumed.
     """
     data = bytes.fromhex('9003000100')
-    msgs = []
-    c = _parsing.parse(data, msgs)
+    c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert len(msgs) == 1
     assert msgs[0].packet_id == 1
@@ -84,8 +81,7 @@ def test_parse_connack():
     A CONNACK for a successful connect is successfuly parsed.
     """
     data = bytes.fromhex('20020000')
-    msgs = []
-    c = _parsing.parse(data, msgs)
+    c, msgs = _parsing.parse(data)
     assert len(data) == c
     assert msgs[0].return_code == 0
     assert msgs[0].session_present == 0
@@ -120,8 +116,7 @@ def test_parse_single_byte_remaining_length(capture_len):
     A single byte remaining length is properly parsed.
     """
     data = bytes.fromhex('31150004746573747b2274657374223a2274657374227d')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[0] == 0x15
 
 
@@ -130,8 +125,7 @@ def test_parse_only_fixed_header(capture_len):
     A single byte remaining length is properly parsed even it
     """
     data = bytes.fromhex('3000')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[0] == 0
 
 def test_parse_two_byte(capture_len):
@@ -139,13 +133,11 @@ def test_parse_two_byte(capture_len):
     A two byte encoded remaining length is properly parsed.
     """
     data = bytes.fromhex('30ff7f1a')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[0] == 16383
 
     data = bytes.fromhex('3080011a')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[1] == 128
 
 def test_parse_three_byte(capture_len):
@@ -153,8 +145,7 @@ def test_parse_three_byte(capture_len):
     A three byte encoded remaining length is properly parsed.
     """
     data = bytes.fromhex('30ffff7f1a')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[0] == 2097151
 
 def test_parse_four_byte(capture_len):
@@ -162,8 +153,7 @@ def test_parse_four_byte(capture_len):
     A four byte encoded remaining length is properly parsed.
     """
     data = bytes.fromhex('30ffffff7f1a')
-    msgs = []
-    _parsing.parse(data, msgs)
+    _parsing.parse(data)
     assert capture_len[0] == 268435455
 
 
@@ -172,17 +162,15 @@ def test_parse_five_byte(capture_len):
     A five byte encoded remaining length is considered an error.
     """
     data = bytes.fromhex('30ffffffff7f')
-    msgs = []
     with pytest.raises(MQTTParseError):
-        _parsing.parse(data, msgs)
+        _parsing.parse(data)
 
 
 def test_parse_disconnect():
     """
     A disconnect packet is successfully parsed.
     """
-    msgs = []
-    r = _parsing.parse(disconnect(), msgs)
+    r, msgs = _parsing.parse(disconnect())
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_DISCONNECT
 
 
@@ -190,8 +178,7 @@ def test_parse_pingresp():
     """
     A ping response returns an appropriate packet.
     """
-    msgs = []
-    r = _parsing.parse(b'\xd0\x00', msgs)
+    r, msgs = _parsing.parse(b'\xd0\x00')
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PINGRESP
 
 
@@ -200,8 +187,7 @@ def test_parse_puback():
     A valid puback is successfully parsed.
     """
     data = bytes.fromhex('40023039')
-    msgs = []
-    r = _parsing.parse(data, msgs)
+    r, msgs = _parsing.parse(data)
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBACK
     assert msgs[0].packet_id == 12345
 
@@ -210,6 +196,5 @@ def test_parse_puback_invalid():
     A invalid puback raises an error.
     """
     data = bytes.fromhex('400130')
-    msgs = []
     with pytest.raises(MQTTInvalidPacketError):
-        _parsing.parse(data, msgs)
+        _parsing.parse(data)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -24,7 +24,7 @@ def test_parse_publish_simple():
     res = json.loads(payload)
     assert res == {"test": "test"}
     assert msgs[0].packetid is None
-    assert msgs[0].topic == u'test'
+    assert msgs[0].topic == 'test'
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBLISH
     assert msgs[0].qos == 0
     assert not msgs[0].dup
@@ -43,7 +43,7 @@ def test_parse_publish_qos():
     res = json.loads(payload)
     assert res == {"test": "test"}
     assert msgs[0].packetid == 3
-    assert msgs[0].topic == u'test'
+    assert msgs[0].topic == 'test'
     assert msgs[0].pkt_type == _constants.MQTT_PACKET_PUBLISH
     assert msgs[0].qos == 1
     assert not msgs[0].dup

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,10 @@
 
 [tox]
 envlist =
-    py27,
-    py36,
+    py39,
+    py310,
+    py311,
+    py312,
     mypy
 
 [testenv]


### PR DESCRIPTION
No need for `six`, `attrs` (replace with `dataclasses`), external `typing`, `binascii.unhexlify`, etc.

I also renamed the `parse(msg: bytes, output: list) -> int` method to `parse_into`, and created a more convenient `parse(msg: bytes) -> tuple(int, list)` method that _returns_ a newly-created `list` of parsed messages.

# Testing

`tox` passing for Python 3.9, 3.10, 3.11, 3.12, and mypy